### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
-  # def index
-  #   @items = Item.order("created_at DESC")
-  # end
+  def index
+    @items = Item.order(created_at: :desc)
+  end
 
   def new
     @item = Item.new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,7 +124,6 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >新規投稿商品</div>
     <ul class='item-lists'>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% if @items.any? %>
         <% @items.each do |item| %>
       <li class='list'>
@@ -132,11 +131,9 @@
           <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-      <%# 商品が売れていればsold outを表示しましょう %>
-      
           <div class='sold-out'><span>Sold Out!!</span></div>
        <% end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
         <div class='item-info'>
           <h3 class='item-name'><%= item.name %></h3>
@@ -151,9 +148,6 @@
         
       </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -171,8 +165,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,53 +119,47 @@
     </ul>
   </div>
   <%# /FURIMAの特徴 %>
-
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <div class="subtitle" >
-      新規投稿商品
-    </div>
+    <div class="subtitle" >新規投稿商品</div>
     <ul class='item-lists'>
-
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items.any? %>
+        <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+      <%# 商品が売れていればsold outを表示しましょう %>
+      
+          <div class='sold-out'><span>Sold Out!!</span></div>
+       <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
+          </div>
         <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
+          <h3 class='item-name'><%= item.name %></h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
+        
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
+          <h3 class='item-name'>商品を出品してね！</h3>
           <div class='item-price'>
             <span>99999999円<br>(税込み)</span>
             <div class='star-btn'>
@@ -176,12 +170,12 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>
-
 </div>
 <%= link_to new_item_path, class: 'purchase-btn' do %>
   <span class='purchase-btn-text'>出品する</span>


### PR DESCRIPTION
# What
### 商品一覧表示機能の実装

# Why
### 1. ユーザーが出品した商品情報が表示されるようにするため
### 2.サイト訪問者が現在出品されている商品情報、およびそれらが売り切れかどうかを確認できるようにするため

- [x] 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/908d5e498b4bfad1a78b32a05243fdda

- [x] 商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/24fcd37a829025897036e096e699813b