### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,11 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.show
+    
+  end
+
   def create
     @item = Item.new(item_params)
     @item.user = current_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,8 +10,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.show
-    
+    @item = Item.find(params[:id])
   end
 
   def create
@@ -24,9 +23,9 @@ class ItemsController < ApplicationController
     end
   end
 
-private
- def item_params
- params.require(:item).permit(:name, :description, :price, :category_id, :condition_id, :shipping_fee_id, :prefecture_id, :shipping_day_id, :image)
-end
+  private
 
+  def item_params
+    params.require(:item).permit(:name, :description, :price, :category_id, :condition_id, :shipping_fee_id, :prefecture_id, :shipping_day_id, :image)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,4 @@
 class Item < ApplicationRecord
-  belongs_to :user
 
   validates :name, presence: true
   validates :description, presence: true
@@ -15,6 +14,7 @@ class Item < ApplicationRecord
 
   extend ActiveHash::Associations::ActiveRecordExtensions
 
+  belongs_to :user
   belongs_to :category
   belongs_to :condition
   belongs_to :shipping_fee

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
       <% if @items.any? %>
         <% @items.each do |item| %>
       <li class='list'>
-          <%= link_to item_path do %>
+          <%= link_to item_path(item) do %>
           <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
       <% if @items.any? %>
         <% @items.each do |item| %>
       <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path do %>
           <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
             <%= @item.shipping_fee.name %>
           </span>
         </div>
-        
+
         <% if user_signed_in? %>
           <% if @item.user==current_user %>
             <%= link_to "商品の編集" , "#" , method: :get, class: "item-red-btn" %>
@@ -36,7 +36,7 @@
           <% end %>
                               <div class="item-explain-box">
                                 <span>
-                                  <%= "商品説明" %>
+                                  <%= @item.description %>
                                 </span>
                               </div>
                               <table class="detail-table">
@@ -44,37 +44,37 @@
                                   <tr>
                                     <th class="detail-item">出品者</th>
                                     <td class="detail-value">
-                                      <%= "出品者名" %>
+                                      <%= @item.user.nickname %>
                                     </td>
                                   </tr>
                                   <tr>
                                     <th class="detail-item">カテゴリー</th>
                                     <td class="detail-value">
-                                      <%= "カテゴリー名" %>
+                                      <%= @item.category.name %>
                                     </td>
                                   </tr>
                                   <tr>
                                     <th class="detail-item">商品の状態</th>
                                     <td class="detail-value">
-                                      <%= "商品の状態" %>
+                                      <%= @item.condition.name %>
                                     </td>
                                   </tr>
                                   <tr>
                                     <th class="detail-item">配送料の負担</th>
                                     <td class="detail-value">
-                                      <%= "発送料の負担" %>
+                                      <%= @item.shipping_fee.name %>
                                     </td>
                                   </tr>
                                   <tr>
                                     <th class="detail-item">発送元の地域</th>
                                     <td class="detail-value">
-                                      <%= "発送元の地域" %>
+                                      <%= @item.prefecture.name %>
                                     </td>
                                   </tr>
                                   <tr>
                                     <th class="detail-item">発送日の目安</th>
                                     <td class="detail-value">
-                                      <%= "発送日の目安" %>
+                                      <%= @item.shipping_day.name %>
                                     </td>
                                   </tr>
                                 </tbody>
@@ -116,7 +116,7 @@
         </div>
         <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
           <a href="#" class="another-item">
-            <%= "商品のカテゴリー名" %>をもっと見る
+            <%= @item.category.name %>をもっと見る
           </a>
           <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -114,11 +114,9 @@
             後ろの商品 ＞
           </a>
         </div>
-        <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
           <a href="#" class="another-item">
             <%= @item.category.name %>をもっと見る
           </a>
-          <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
     </div>
 
     <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,111 +1,124 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
-<div class="item-show">
-  <div class="item-box">
-    <h2 class="name">
-      <%= "商品名" %>
-    </h2>
-    <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
+  <%# 商品の概要 %>
+    <div class="item-show">
+      <div class="item-box">
+        <h2 class="name">
+          <%= @item.name %>
+        </h2>
+        <div class="item-img-content">
+          <%= image_tag @item.image ,class:"item-box-img" %>
+            <%# 商品が売れている場合は、sold outを表示しましょう %>
+              <div class="sold-out">
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れている場合は、sold outを表示しましょう %>
+        </div>
+        <div class="item-price-box">
+          <span class="item-price">
+            <%= @item.price %>円
+          </span>
+          <span class="item-postage">
+            <%= @item.shipping_fee.name %>
+          </span>
+        </div>
+        
+        <% if user_signed_in? %>
+          <% if @item.user==current_user %>
+            <%= link_to "商品の編集" , "#" , method: :get, class: "item-red-btn" %>
+              <p class="or-text">or</p>
+              <%= link_to "削除" , "#" , data: {turbo_method: :delete}, class:"item-destroy" %>
+                <% else %>
+                  <%# 商品が売れていない場合はこちらを表示しましょう %>
+                    <%= link_to "購入画面に進む" , "#" ,class:"item-red-btn"%>
+                      <%# //商品が売れていない場合はこちらを表示しましょう %>
+             <% end %>
+          <% end %>
+                              <div class="item-explain-box">
+                                <span>
+                                  <%= "商品説明" %>
+                                </span>
+                              </div>
+                              <table class="detail-table">
+                                <tbody>
+                                  <tr>
+                                    <th class="detail-item">出品者</th>
+                                    <td class="detail-value">
+                                      <%= "出品者名" %>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <th class="detail-item">カテゴリー</th>
+                                    <td class="detail-value">
+                                      <%= "カテゴリー名" %>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <th class="detail-item">商品の状態</th>
+                                    <td class="detail-value">
+                                      <%= "商品の状態" %>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <th class="detail-item">配送料の負担</th>
+                                    <td class="detail-value">
+                                      <%= "発送料の負担" %>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <th class="detail-item">発送元の地域</th>
+                                    <td class="detail-value">
+                                      <%= "発送元の地域" %>
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <th class="detail-item">発送日の目安</th>
+                                    <td class="detail-value">
+                                      <%= "発送日の目安" %>
+                                    </td>
+                                  </tr>
+                                </tbody>
+                              </table>
+                              <div class="option">
+                                <div class="favorite-btn">
+                                  <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+                                    <span>お気に入り 0</span>
+                                </div>
+                                <div class="report-btn">
+                                  <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+                                    <span>不適切な商品の通報</span>
+                                </div>
+                              </div>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# /商品の概要 %>
+
+        <div class="comment-box">
+          <form>
+            <textarea class="comment-text"></textarea>
+            <p class="comment-warn">
+              相手のことを考え丁寧なコメントを心がけましょう。
+              <br>
+              不快な言葉遣いなどは利用制限や退会処分となることがあります。
+            </p>
+            <button type="submit" class="comment-btn">
+              <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+                <span>コメントする<span>
+            </button>
+          </form>
+        </div>
+        <div class="links">
+          <a href="#" class="change-item-btn">
+            ＜ 前の商品
+          </a>
+          <a href="#" class="change-item-btn">
+            後ろの商品 ＞
+          </a>
+        </div>
+        <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+          <a href="#" class="another-item">
+            <%= "商品のカテゴリー名" %>をもっと見る
+          </a>
+          <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
     </div>
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ 999,999,999
-      </span>
-      <span class="item-postage">
-        <%= "配送料負担" %>
-      </span>
-    </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
-    </div>
-    <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
-      </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
-      </div>
-    </div>
-  </div>
-  <%# /商品の概要 %>
-
-  <div class="comment-box">
-    <form>
-      <textarea class="comment-text"></textarea>
-      <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      </p>
-      <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
-      </button>
-    </form>
-  </div>
-  <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
-  </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-</div>
-
-<%= render "shared/footer" %>
+    <%= render "shared/footer" %>


### PR DESCRIPTION
## What
### 商品詳細表示機能の実装

## Why
### 1. ユーザーが出品した商品情報を閲覧できるようにするため
### 2. サイト訪問者が現在出品されている商品情報を閲覧できるようにするため

- [x] ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
284134889108d6ae91277cd72041a1d4

- [x] ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画 
https://gyazo.com/894b55b4084334b6a2f70da558e79920

- [x] ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能未実装

- [x] ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/ce51734ce9a45d39378e45c1ffac841b
 
